### PR TITLE
Update AppliedEnergistics2.cfg

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -90,9 +90,9 @@ craftingcpu {
 features {
 
     world {
-        B:CertusOre=false
-        B:CertusQuartzWorldGen=false
-        B:ChargedCertusOre=false
+        B:CertusOre=true
+        B:CertusQuartzWorldGen=true
+        B:ChargedCertusOre=true
         B:ChestLoot=false
 
         # Blocks that are not used in any essential recipes, also slabs and stairs.


### PR DESCRIPTION
Changed "certus ore" and "charged certus ore" world gen to true so they will spawn in deep dark.